### PR TITLE
rho.simple.fixed 

### DIFF
--- a/calibration/BRICK_calib_driver.R
+++ b/calibration/BRICK_calib_driver.R
@@ -25,22 +25,18 @@
 ## along with BRICK.  If not, see <http://www.gnu.org/licenses/>.
 ##==============================================================================
 
-setwd('~/codes/BRICK/calibration')
-
 rm(list=ls())                        # Clear all previous variables
 
 ## Switch to your BRICK calibration directory
-setwd('/home/scrim/axw322/codes/BRICK/calibration')
+#setwd('/home/scrim/axw322/codes/BRICK/calibration')
+setwd('/Users/tony/codes/BRICK/calibration')
 
 ## Set up MCMC stuff here so that it can be automated for HPC
-nnode_mcmc000 <- 8
-niter_mcmc000 <- 1e6
+nnode_mcmc000 <- 1
+niter_mcmc000 <- 1e4
 
 ## Show plots? (probably want FALSE on HPC, non-interactive)
 l.doplots <- FALSE
-
-## Use an old estimate of rho.simple?
-l.oldrhosimple <- FALSE
 
 ## Set up a filename for saving RData images along the way
 today=Sys.Date(); today=format(today,format="%d%b%Y")
@@ -261,43 +257,6 @@ lines(obs.gis.time[oidx.gis], brick.out$simple.out$sle.gis[midx.gis], col="blue"
 plot(obs.sl.time[oidx.sl], obs.sl[oidx.sl], pch=20, ylab = 'sea level [m]', xlab='year')
 lines(brick.out$doeclim.out$time[midx.sl], brick.out$slr.out[midx.sl], col="purple", lwd=2)
 }
-##==============================================================================
-
-## Fix the SIMPLE (GIS) rho.simple statistical parameter at value from the
-## optimized coupled model. There are problems of convergence when it is
-## free-running in the calibration, caused by the high degree of autocorrelation
-## in the GIS residuals. The sigma.simple parameter also was trouble, but not
-## anymore (if convergence issues arise, this might be why).
-
-if(luse.simple) {
-
-  sigma.simple.fixed = NULL
-  rho.simple.fixed   = NULL
-
-  ## Read an old rho.simple.fixed?
-  if(l.oldrhosimple){
-    rho.simple.fixed = as.numeric(read.csv('../output_calibration/rho_simple_fixed_07May2017.csv'))
-  } else {
-    ## If rho/sigma.simple.fixed = NULL, then will be calibrated
-    resid = brick.out$simple.out$sle.gis[midx.gis] - obs.gis[oidx.gis]
-    ac = acf(resid, lag.max=5, plot=FALSE, main="")
-
-    ## If not in the declared parameter names, then fix the estimate of the
-    ## AR(1) process sqrt(variance) and autocorrelation
-    if(is.na(match("sigma.simple",parnames))) sigma.simple.fixed = sd(resid)
-    if(is.na(match("rho.simple",parnames)))   rho.simple.fixed = ac$acf[2]
-
-    ## rho.simple.fixed should be somewhere around 0.85-0.90
-    ## Fix it at a value you decide. Model results are insensitive to this choice,
-    ## provided it is realistic (between 0.85 and 1). Write to a file.
-
-    today=Sys.Date(); today=format(today,format="%d%b%Y")
-    filename=paste('../output_calibration/rho_simple_fixed_',today,'.csv', sep="")
-    write.table(rho.simple.fixed, file=filename, sep=",", qmethod="double", row.names=FALSE)
-  }
-  print(paste('rho.simple.fixed=',rho.simple.fixed))
-
-}
 
 ##==============================================================================
 ## Establish a gamma prior for drawing 1/tau.
@@ -381,6 +340,12 @@ nnode.mcmc = nnode_mcmc000        # number of nodes for parallel MCMC
 gamma.mcmc = 0.5                  # rate of adaptation (between 0.5 and 1, lower is faster adaptation)
 burnin = round(niter.mcmc*0.5)    # remove first ?? of chains for burn-in (not used)
 stopadapt.mcmc = round(niter.mcmc*1.0)# stop adapting after ?? iterations? (niter*1 => don't stop)
+
+
+## TONY TESTING
+rho.simple.fixed <- NULL
+sigma.simple.fixed <- NULL
+## END TONY TESTING
 
 ##==============================================================================
 ## Actually run the calibration

--- a/calibration/BRICK_calib_driver.R
+++ b/calibration/BRICK_calib_driver.R
@@ -28,12 +28,12 @@
 rm(list=ls())                        # Clear all previous variables
 
 ## Switch to your BRICK calibration directory
-#setwd('/home/scrim/axw322/codes/BRICK/calibration')
-setwd('/Users/tony/codes/BRICK/calibration')
+setwd('/home/scrim/axw322/codes/BRICK/calibration')
+#setwd('/Users/tony/codes/BRICK/calibration')
 
 ## Set up MCMC stuff here so that it can be automated for HPC
-nnode_mcmc000 <- 1
-niter_mcmc000 <- 1e4
+nnode_mcmc000 <- 8
+niter_mcmc000 <- 2e6
 
 ## Show plots? (probably want FALSE on HPC, non-interactive)
 l.doplots <- FALSE
@@ -341,12 +341,6 @@ gamma.mcmc = 0.5                  # rate of adaptation (between 0.5 and 1, lower
 burnin = round(niter.mcmc*0.5)    # remove first ?? of chains for burn-in (not used)
 stopadapt.mcmc = round(niter.mcmc*1.0)# stop adapting after ?? iterations? (niter*1 => don't stop)
 
-
-## TONY TESTING
-rho.simple.fixed <- NULL
-sigma.simple.fixed <- NULL
-## END TONY TESTING
-
 ##==============================================================================
 ## Actually run the calibration
 if(FALSE){
@@ -359,9 +353,7 @@ amcmc.out1 = MCMC(log.post, niter.mcmc, p0.deoptim, scale=step.mcmc, adapt=TRUE,
                   oidx = oidx.all                , midx = midx.all            , obs=obs.all                   ,
                   obs.err = obs.err.all          , trends.te = trends.te      , bound.lower.in=bound.lower    ,
                   bound.upper.in=bound.upper     , shape.in=shape.invtau      , scale.in=scale.invtau         ,
-                  rho.simple.in=rho.simple.fixed , sigma.simple.in=sigma.simple.fixed, luse.brick=luse.brick  ,
-                  i0=i0                          , l.aisfastdy=l.aisfastdy
-                  )
+                  luse.brick=luse.brick          , i0=i0                      , l.aisfastdy=l.aisfastdy       )
 t.end=proc.time()                      # save timing
 chain1 = amcmc.out1$samples
 }
@@ -376,9 +368,7 @@ amcmc.extend1 = MCMC.add.samples(amcmc.out1, niter.mcmc,
                     oidx = oidx.all                , midx = midx.all            , obs=obs.all                    ,
                     obs.err = obs.err.all          , trends.te = trends.te      , bound.lower.in=bound.lower     ,
                     bound.upper.in=bound.upper     , shape.in=shape.invtau      , scale.in=scale.invtau          ,
-                    rho.simple.in=rho.simple.fixed , sigma.simple.in=sigma.simple.fixed, luse.brick=luse.brick   ,
-                    i0=i0                          , l.aisfastdy=l.aisfastdy
-                    )
+                    luse.brick=luse.brick          , i0=i0                      , l.aisfastdy=l.aisfastdy        )
 t.end=proc.time()
 chain1 = amcmc.extend1$samples
 }
@@ -396,9 +386,7 @@ amcmc.par1 = MCMC.parallel(log.post, niter.mcmc, p0.deoptim, n.chain=nnode.mcmc,
                   oidx = oidx.all                , midx = midx.all            , obs=obs.all                   ,
                   obs.err = obs.err.all          , trends.te = trends.te      , bound.lower.in=bound.lower    ,
                   bound.upper.in=bound.upper     , shape.in=shape.invtau      , scale.in=scale.invtau         ,
-                  rho.simple.in=rho.simple.fixed , sigma.simple.in=sigma.simple.fixed, luse.brick=luse.brick  ,
-                  i0=i0                          , l.aisfastdy=l.aisfastdy
-                  )
+                  luse.brick=luse.brick          , i0=i0                      , l.aisfastdy=l.aisfastdy       )
 t.end=proc.time()                      # save timing
 }
 

--- a/calibration/BRICK_parameterSetup.R
+++ b/calibration/BRICK_parameterSetup.R
@@ -79,11 +79,11 @@ if (luse.te) {
 parnames.simple   =NULL; p0.simple       =NULL; bound.lower.simple=NULL;
 bound.upper.simple=NULL; step.mcmc.simple=NULL; index.model.simple=NULL;
 if (luse.simple) {
-	parnames.simple   =c("a.simple" ,"b.simple" ,"alpha.simple","beta.simple","V0"      ,"sigma.simple") # parameters names
-	p0.simple         =c(-0.825     , 7.36      , 1.63e-4      , 2.85e-5     , 7.36     , 5e-4         ) # initial parameter guesses
-	bound.lower.simple=c( -4        , 5.888     , 0            , 0           , 7.16     , 0            ) # prior range lower bounds
-	bound.upper.simple=c( -1e-3     , 8.832     , 1e-3         , 1e-3        , 7.56     , 0.002        ) # prior range upper bounds
-	step.mcmc.simple  =c( 0.2       , 0.05      , 1e-5         , 1e-5        , 0.05     , 0.0001       ) # step sizes for initial MCMC
+	parnames.simple   =c("a.simple" ,"b.simple" ,"alpha.simple","beta.simple","V0"      ,"sigma.simple","rho.simple") # parameters names
+	p0.simple         =c(-0.825     , 7.36      , 1.63e-4      , 2.85e-5     , 7.36     , 5e-4         , 0.5        ) # initial parameter guesses
+	bound.lower.simple=c( -4        , 5.888     , 0            , 0           , 7.16     , 0            , -0.999     ) # prior range lower bounds
+	bound.upper.simple=c( -1e-3     , 8.832     , 1e-3         , 1e-3        , 7.56     , 0.002        ,  0.999     ) # prior range upper bounds
+	step.mcmc.simple  =c( 0.2       , 0.05      , 1e-5         , 1e-5        , 0.05     , 0.0001       ,  0.1       ) # step sizes for initial MCMC
 	index.model.simple=c(1,2,3,4,5)			# which are model parameters? (index within parnames.simple)
 }
 

--- a/calibration/DAIS_calib_driver.R
+++ b/calibration/DAIS_calib_driver.R
@@ -38,12 +38,12 @@
 rm(list =ls()) #Clear global environment
 
 ## Switch to your BRICK calibration directory
-#setwd('/home/scrim/axw322/codes/BRICK/calibration')
-setwd('/Users/tony/codes/BRICK/calibration')
+setwd('/home/scrim/axw322/codes/BRICK/calibration')
+#setwd('/Users/tony/codes/BRICK/calibration')
 
 ## Set up MCMC stuff here so that it can be automated for HPC
-nnode_mcmc000 <- 1
-niter_mcmc000 <- 100
+nnode_mcmc000 <- 8
+niter_mcmc000 <- 1e6
 
 ## Set up a filename for saving RData images along the way
 today=Sys.Date(); today=format(today,format="%d%b%Y")

--- a/calibration/compare_old_new_projections.R
+++ b/calibration/compare_old_new_projections.R
@@ -42,8 +42,8 @@ setwd('~/codes/BRICK/output_model')
 ## define files that result from the rejection sampling calibration to GMSL
 ## (these file names are relative to the "BRICK/output_model" directory)
 
-filename.old <- 'BRICK_physical_fd-gamma_08May2017.nc'
-filename.new <- 'BRICK-model_physical_fd-gamma_13Aug2017.nc'
+filename.old <- 'BRICK-model_physical_fd-gamma_13Aug2017.nc'
+filename.new <- 'BRICK-model_physical_fd-gamma_17Aug2017.nc'
 
 ## define reference period (beginning and end years)
 ## if this is NULL, projections will be relative to 1986-2005 global mean sea
@@ -203,7 +203,7 @@ for (year in project.years.names) {
 ##==============================================================================
 
 # fit kernel density estimates to each of the sets of projections
-tmp <- density(x=sf.sealev[[rcp]][[ais]], from=lsl.lower, to=lsl.upper, n=lsl.n, kernel=kern)
+#tmp <- density(x=sf.sealev[[rcp]][[ais]], from=lsl.lower, to=lsl.upper, n=lsl.n, kernel=kern)
 
 # TODO
 # TODO!

--- a/calibration/mcmc_brick.pbs
+++ b/calibration/mcmc_brick.pbs
@@ -5,4 +5,4 @@
 #PBS -m abe
 #PBS -M twong@psu.edu
 
-R --vanilla < /home/scrim/axw322/codes/BRICK/calibration/BRICK_calib_driver.R > /home/scrim/axw322/codes/BRICK/calibration/mcmc_brick.log
+R --vanilla < /home/scrim/axw322/codes/BRICK/calibration/BRICK_calib_driver.R > /home/scrim/axw322/codes/BRICK/calibration/mcmc_brick_rhosimple.log

--- a/calibration/mcmc_dais.pbs
+++ b/calibration/mcmc_dais.pbs
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -l walltime=48:00:00
+#PBS -l walltime=96:00:00
 #PBS -l nodes=1:ppn=10
 #PBS -j oe
 #PBS -m abe

--- a/calibration/processingPipeline_BRICKexperiments.R
+++ b/calibration/processingPipeline_BRICKexperiments.R
@@ -111,9 +111,9 @@ n.ensemble.gmsl = 500    # pick n.ensemble for BRICK-GMSL to match control
 n.ensemble.report = n.ensemble
 
 if(experiment=='c'){
-  filename.rho_simple_fixed = "../output_calibration/rho_simple_fixed_12Aug2017.csv"
-  filename.BRICKcalibration = "../output_calibration/BRICK-model_calibratedParameters_13Aug2017.nc"
-  filename.DAIScalibration  = "../output_calibration/DAIS_calibratedParameters_12Aug2017.nc"
+#  filename.rho_simple_fixed = "../output_calibration/rho_simple_fixed_12Aug2017.csv"
+  filename.BRICKcalibration = "../output_calibration/BRICK-model_calibratedParameters_16Aug2017.nc"
+  filename.DAIScalibration  = "../output_calibration/DAIS_calibratedParameters_17Aug2017.nc"
   filename.parameters       = paste('../output_calibration/BRICK-model_postcalibratedParameters_control_',today,appen,'.nc', sep="")
   filename.brickout         = paste('../output_model/BRICK-model_physical_control_',today,appen,'.nc',sep="")
   filename.vdout            = paste('../output_model/VanDantzig_RCP85_control_',today,appen,'.nc',sep="")
@@ -397,7 +397,7 @@ save.image(file=filename.saveprogress)
 
 ## Read rho.simple from file
 rho.simple.fixed=NA
-if(experiment!='g') {rho.simple.fixed = as.numeric(read.csv(filename.rho_simple_fixed))}
+if(exists('filename.rho_simple_fixed') & experiment!='g') {rho.simple.fixed = as.numeric(read.csv(filename.rho_simple_fixed))}
 
 ## Gather the fields for each simulation (easy referencing for plotting and
 ## analysis)


### PR DESCRIPTION
add rho.simple (AR1 autocorrelation coefficient term for greenland ice sheet) back into the calibration. was originally left out due to convergence problems, but a number of bug fixes since then have fixed this issue.