### PR TITLE
Set maximum contribution from gsic to V0

### DIFF
--- a/fortran/src/gsic_magicc.f90
+++ b/fortran/src/gsic_magicc.f90
@@ -113,6 +113,9 @@ subroutine gsic_magicc_step_forward(Tg, SeaLevel)
 
 ! Start model
     SeaLevel = Gs + tstep * (beta0 * (Tg - Teq) * (1.-(Gs/V0))**n)
+    IF( SeaLevel_Current .GT. V0 ) THEN
+        SeaLevel_Current = V0
+    ENDIF
     Gs       = SeaLevel
 
 end subroutine gsic_magicc_step_forward


### PR DESCRIPTION
This addresses issue #27, where GSIC produces NaNs when it tries to calculate after full melt