### PR TITLE
tiny bug with the invtau prior

### DIFF
--- a/calibration/BRICK_calib_driver.R
+++ b/calibration/BRICK_calib_driver.R
@@ -294,6 +294,9 @@ if(luse.te) {
   # This, and future versions, will hand-pick.
   shape.invtau <- 1.81
   scale.invtau <- 0.00275
+} else{
+  shape.invtau <- NULL
+  scale.invtau <- NULL
 }
 
 ##==============================================================================


### PR DESCRIPTION
invtau prior information is always passed, even when unused. Currently, using TEE causes a crash with undefined shape.invtau. Many ways to fix this issue; feel free to choose another.