### PR TITLE
Two small fixes to get BRICK to run

### DIFF
--- a/calibration/BRICK_calib_driver.R
+++ b/calibration/BRICK_calib_driver.R
@@ -350,7 +350,7 @@ library(adaptMCMC)                # use robust adaptive Metropolis
 accept.mcmc = 0.234               # Optimal as # parameters->infinity
                                   # (Gelman et al, 1996; Roberts et al, 1997)
 niter.mcmc = 1e6                  # number of iterations for MCMC
-gamma.mcmc = 0.5                  # rate of adaptation (between 0.5 and 1, lower is faster adaptation)
+gamma.mcmc = 0.51                 # rate of adaptation (between 0.5 and 1, lower is faster adaptation)
 burnin = round(niter.mcmc*0.5)    # remove first ?? of chains for burn-in (not used)
 stopadapt.mcmc = round(niter.mcmc*1.0)# stop adapting after ?? iterations? (niter*1 => don't stop)
 

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -96,7 +96,7 @@ $(OP)/CCM.o: $(OP)/global.o $(SP)/CCM.f90
 
 ## MOC box model ##
 $(OP)/moc_boxmodel.o: $(OP)/global.o $(OP)/rndseed.o $(OP)/moc_boxmodel.F90
-	$(F90) -c $(Flags) $(Incl) $(SP)/moc_boxmodel.f90 -o $@
+	$(F90) -c $(Flags) $(Incl) $(SP)/moc_boxmodel.F90 -o $@
 
 $(OP)/rndseed.o:  $(OP)/global.o $(OP)/mt19937ar.o $(SP)/rndseed.f90
 	$(F90) -c $(Flags) $(Incl) $(SP)/rndseed.f90 -o $@


### PR DESCRIPTION
This PR adds to small fixes to get the BRICKms branch to run on my computer:
1. Change one file extension from .f90 to .F90 to force preprocessor to run before compiling.
2. Slightly increase the gamma.mcmc parameter so it is within the range allowed by the MCMC R package.